### PR TITLE
Uses UDR ROCK instead of upstream image

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ juju integrate sdcore-nrf sdcore-udr:fiveg_nrf
 
 ## Image
 
-- **udr**: `omecproject/5gc-udr:master-6956659`
+- **udr**: `ghcr.io/canonical/sdcore-udr:1.3`

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,7 +22,7 @@ resources:
   udr-image:
     type: oci-image
     description: OCI image for SD-Core's UDR
-    upstream-source: omecproject/5gc-udr:master-35eb7b7
+    upstream-source: ghcr.io/canonical/sdcore-udr:1.3
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -226,7 +226,7 @@ class UDROperatorCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": "/free5gc/udr/udr "
+                        "command": "/bin/udr "
                         f"-udrcfg {BASE_CONFIG_PATH}/{UDR_CONFIG_FILE_NAME}",
                         "environment": self._environment_variables,
                     }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -15,7 +15,7 @@ TEST_PEBBLE_LAYER = {
         "udr": {
             "override": "replace",
             "startup": "enabled",
-            "command": "/free5gc/udr/udr -udrcfg /free5gc/config/udrcfg.yaml",
+            "command": "/bin/udr -udrcfg /free5gc/config/udrcfg.yaml",
             "environment": {
                 "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
                 "GRPC_GO_LOG_SEVERITY_LEVEL": "info",


### PR DESCRIPTION
# Description

Uses the UDR ROCK in the charm instead of the upstream image.
Don't merge before the [ROCK](https://github.com/canonical/sdcore-udr-rock/pull/1) is merged.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library