### PR TITLE
(TELCO-574) Block charm when NRF goes down

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jinja2
 lightkube
 lightkube-models
-ops
+ops==2.4.1
 pydantic
 pytest-interface-tester
 jsonschema

--- a/src/charm.py
+++ b/src/charm.py
@@ -63,6 +63,7 @@ class UDROperatorCharm(CharmBase):
         self.framework.observe(self._database.on.database_created, self._configure_udr)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_udr)
         self.framework.observe(self._nrf.on.nrf_available, self._configure_udr)
+        self.framework.observe(self._nrf.on.nrf_broken, self._on_nrf_broken)
         self.framework.observe(
             self.on.certificates_relation_created, self._on_certificates_relation_created
         )
@@ -118,6 +119,14 @@ class UDROperatorCharm(CharmBase):
         self._generate_udr_config_file()
         self._configure_udr_service()
         self.unit.status = ActiveStatus()
+
+    def _on_nrf_broken(self, event: EventBase) -> None:
+        """Event handler for NRF relation broken.
+
+        Args:
+            event (NRFBrokenEvent): Juju event
+        """
+        self.unit.status = BlockedStatus("Waiting for fiveg_nrf relation")
 
     def _on_certificates_relation_created(self, event: EventBase) -> None:
         """Generates Private key."""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -21,17 +22,17 @@ TLS_PROVIDER_CHARM_NAME = "self-signed-certificates"
 class TestUDROperatorCharm:
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail
-    async def setup(self, ops_test):
+    async def setup(self, ops_test: OpsTest):
         await self._deploy_mongodb(ops_test)
         await self._deploy_sdcore_nrf_operator(ops_test)
         await self._deploy_tls_provider(ops_test)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail
-    async def build_and_deploy_charm(self, ops_test):
+    async def build_and_deploy_charm(self, ops_test: OpsTest):
         charm = await ops_test.build_charm(".")
         resources = {"udr-image": METADATA["resources"]["udr-image"]["upstream-source"]}
-        await ops_test.model.deploy(
+        await ops_test.model.deploy(  # type: ignore[union-attr]
             charm,
             resources=resources,
             application_name=APPLICATION_NAME,
@@ -39,8 +40,8 @@ class TestUDROperatorCharm:
         )
 
     @staticmethod
-    async def _deploy_mongodb(ops_test):
-        await ops_test.model.deploy(
+    async def _deploy_mongodb(ops_test: OpsTest):
+        await ops_test.model.deploy(  # type: ignore[union-attr]
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="5/edge",
@@ -48,37 +49,64 @@ class TestUDROperatorCharm:
         )
 
     @staticmethod
-    async def _deploy_tls_provider(ops_test):
-        await ops_test.model.deploy(
+    async def _deploy_tls_provider(ops_test: OpsTest):
+        await ops_test.model.deploy(  # type: ignore[union-attr]
             TLS_PROVIDER_CHARM_NAME,
             application_name=TLS_PROVIDER_CHARM_NAME,
             channel="edge",
         )
 
     @staticmethod
-    async def _deploy_sdcore_nrf_operator(ops_test):
-        await ops_test.model.deploy(
+    async def _deploy_sdcore_nrf_operator(ops_test: OpsTest):
+        await ops_test.model.deploy(  # type: ignore[union-attr]
             NRF_APPLICATION_NAME,
             application_name=NRF_APPLICATION_NAME,
             channel="edge",
             trust=True,
         )
-        await ops_test.model.add_relation(
+        await ops_test.model.add_relation(  # type: ignore[union-attr]
             relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME
         )
 
-    async def test_wait_for_blocked_status(self, ops_test, setup, build_and_deploy_charm):
-        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
+    @pytest.mark.abort_on_fail
+    async def test_wait_for_blocked_status(self, ops_test: OpsTest, setup, build_and_deploy_charm):
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
 
-    async def test_relate_and_wait_for_idle(self, ops_test, setup, build_and_deploy_charm):
-        await ops_test.model.add_relation(
+    @pytest.mark.abort_on_fail
+    async def test_relate_and_wait_for_idle(
+        self, ops_test: OpsTest, setup, build_and_deploy_charm
+    ):
+        await ops_test.model.add_relation(  # type: ignore[union-attr]
             relation1=f"{APPLICATION_NAME}:database", relation2=DB_APPLICATION_NAME
         )
-        await ops_test.model.add_relation(
+        await ops_test.model.add_relation(  # type: ignore[union-attr]
             relation1=f"{APPLICATION_NAME}:fiveg_nrf", relation2=NRF_APPLICATION_NAME
         )
-        await ops_test.model.add_relation(
+        await ops_test.model.add_relation(  # type: ignore[union-attr]
             relation1=f"{APPLICATION_NAME}:certificates",
             relation2=f"{TLS_PROVIDER_CHARM_NAME}:certificates",
         )
-        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
+
+    @pytest.mark.abort_on_fail
+    async def test_remove_nrf_and_wait_for_blocked_status(
+        self, ops_test: OpsTest, setup, build_and_deploy_charm
+    ):
+        await ops_test.model.remove_application(NRF_APPLICATION_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+
+    @pytest.mark.abort_on_fail
+    async def test_restore_nrf_and_wait_for_active_status(
+        self, ops_test: OpsTest, setup, build_and_deploy_charm
+    ):
+        await ops_test.model.deploy(  # type: ignore[union-attr]
+            NRF_APPLICATION_NAME,
+            application_name=NRF_APPLICATION_NAME,
+            channel="edge",
+            trust=True,
+        )
+        await ops_test.model.add_relation(  # type: ignore[union-attr]
+            relation1=f"{NRF_APPLICATION_NAME}:database", relation2=DB_APPLICATION_NAME
+        )
+        await ops_test.model.add_relation(relation1=APPLICATION_NAME, relation2=NRF_APPLICATION_NAME)  # type: ignore[union-attr]  # noqa: E501
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=300)  # type: ignore[union-attr]  # noqa: E501

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -23,7 +23,7 @@ class TestUDROperatorCharm:
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test: OpsTest):
-        await ops_test.model.set_config({"update-status-hook-interval": "5s"})
+        await ops_test.model.set_config({"update-status-hook-interval": "5s"})  # type: ignore[union-attr]  # noqa: E501
         await self._deploy_mongodb(ops_test)
         await self._deploy_sdcore_nrf_operator(ops_test)
         await self._deploy_tls_provider(ops_test)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -23,6 +23,7 @@ class TestUDROperatorCharm:
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test: OpsTest):
+        await ops_test.model.set_config({"update-status-hook-interval": "5s"})
         await self._deploy_mongodb(ops_test)
         await self._deploy_sdcore_nrf_operator(ops_test)
         await self._deploy_tls_provider(ops_test)


### PR DESCRIPTION
# Description

This PR adds handling of the NRF relation broken event.
If NRF will ever go down, the UDR charm will reflect that fact by going into `Blocked` state.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library