### PR TITLE
Enforce TLS Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,11 @@ A Charmed Operator for SD-Core's Unified Data Repository (UDR) component.
 juju deploy mongodb-k8s --trust --channel=5/edge
 juju deploy sdcore-nrf --trust --channel=edge
 juju deploy sdcore-udr --trust --channel=edge
+juju deploy self-signed-certificates --channel=beta
 juju integrate mongodb-k8s sdcore-nrf
 juju integrate mongodb-k8s sdcore-udr:database
+juju integrate sdcore-nrf:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf sdcore-udr:fiveg_nrf
-```
-
-## Optional
-
-```bash
-juju deploy self-signed-certificates --channel=edge
 juju integrate sdcore-udr:certificates self-signed-certificates:certificates
 ```
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -25,8 +25,8 @@ class TestUDROperatorCharm:
     async def setup(self, ops_test: OpsTest):
         await ops_test.model.set_config({"update-status-hook-interval": "5s"})  # type: ignore[union-attr]  # noqa: E501
         await self._deploy_mongodb(ops_test)
-        await self._deploy_sdcore_nrf_operator(ops_test)
         await self._deploy_tls_provider(ops_test)
+        await self._deploy_sdcore_nrf_operator(ops_test)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail
@@ -68,6 +68,9 @@ class TestUDROperatorCharm:
         await ops_test.model.add_relation(  # type: ignore[union-attr]
             relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME
         )
+        await ops_test.model.add_relation(  # type: ignore[union-attr]
+            relation1=TLS_PROVIDER_CHARM_NAME, relation2=NRF_APPLICATION_NAME
+        )
 
     @pytest.mark.abort_on_fail
     async def test_wait_for_blocked_status(self, ops_test: OpsTest, setup, build_and_deploy_charm):
@@ -82,9 +85,6 @@ class TestUDROperatorCharm:
         )
         await ops_test.model.add_relation(  # type: ignore[union-attr]
             relation1=f"{APPLICATION_NAME}:fiveg_nrf", relation2=NRF_APPLICATION_NAME
-        )
-        await ops_test.model.add_relation(  # type: ignore[union-attr]
-            relation1=f"{NRF_APPLICATION_NAME}:certificates", relation2=TLS_PROVIDER_CHARM_NAME
         )
         await ops_test.model.add_relation(  # type: ignore[union-attr]
             relation1=f"{APPLICATION_NAME}:certificates",

--- a/tests/unit/resources/expected_udrcfg.yaml
+++ b/tests/unit/resources/expected_udrcfg.yaml
@@ -4,7 +4,7 @@ info:
 
 configuration:
   sbi: # Service-based interface information
-    scheme: http
+    scheme: https
     registerIPv4: 1.2.3.4
     bindingIPv4: 0.0.0.0
     port: 29504

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -55,16 +55,6 @@ class TestCharm(unittest.TestCase):
             },
         )
 
-    def _create_certificates_relation(self) -> int:
-        """Creates certificates relation.
-
-        Returns:
-            int: relation id.
-        """
-        return self.harness.add_relation(
-            relation_name="certificates", remote_app="tls-certificates-operator"
-        )
-
     def test_given_database_relation_not_created_when_pebble_ready_then_status_is_blocked(self):
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self.harness.container_pebble_ready("udr")
@@ -121,7 +111,9 @@ class TestCharm(unittest.TestCase):
     ):
         self.harness.add_relation(relation_name="database", remote_app="some_db_app")
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.container_pebble_ready("udr")
         self.assertEqual(
             self.harness.model.unit.status,
@@ -135,7 +127,9 @@ class TestCharm(unittest.TestCase):
         patched_is_resource_created.return_value = True
         self.harness.add_relation(relation_name="database", remote_app="some_db_app")
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.container_pebble_ready("udr")
         self.assertEqual(
             self.harness.model.unit.status,
@@ -149,7 +143,9 @@ class TestCharm(unittest.TestCase):
         patched_is_resource_created.return_value = True
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.container_pebble_ready("udr")
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for the NRF to be available")
@@ -164,7 +160,9 @@ class TestCharm(unittest.TestCase):
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.container_pebble_ready("udr")
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for the storage to be attached")
@@ -187,7 +185,9 @@ class TestCharm(unittest.TestCase):
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.container_pebble_ready("udr")
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for certificates to be stored")
@@ -212,7 +212,9 @@ class TestCharm(unittest.TestCase):
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
 
         self.harness.container_pebble_ready("udr")
 
@@ -246,7 +248,9 @@ class TestCharm(unittest.TestCase):
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
 
         self.harness.container_pebble_ready("udr")
 
@@ -309,7 +313,9 @@ class TestCharm(unittest.TestCase):
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.set_can_connect(container="udr", val=True)
         self._container.add_layer("udr", TEST_PEBBLE_LAYER, combine=True)
 
@@ -365,7 +371,9 @@ class TestCharm(unittest.TestCase):
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
 
         self.harness.container_pebble_ready("udr")
 
@@ -391,7 +399,9 @@ class TestCharm(unittest.TestCase):
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.container_pebble_ready("udr")
         patched_restart.assert_called_once_with("udr")
 
@@ -412,7 +422,9 @@ class TestCharm(unittest.TestCase):
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.container_pebble_ready("udr")
         self.assertEqual(
             self.harness.model.unit.status,
@@ -436,7 +448,9 @@ class TestCharm(unittest.TestCase):
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
-        self._create_certificates_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
 
         self.harness.container_pebble_ready("udr")
 


### PR DESCRIPTION
# Description

Enforces TLS integration in the charm. Charm remains in blocked state until the `certificates` relation is created, and in waiting status until a certificate is stored.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library