### PR TITLE
fix: go into blocked status when database relation is removed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -60,6 +60,7 @@ class UDROperatorCharm(CharmBase):
 
         self.framework.observe(self.on.udr_pebble_ready, self._configure_udr)
         self.framework.observe(self.on.database_relation_joined, self._configure_udr)
+        self.framework.observe(self.on.database_relation_broken, self._on_database_relation_broken)
         self.framework.observe(self._database.on.database_created, self._configure_udr)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_udr)
         self.framework.observe(self._nrf.on.nrf_available, self._configure_udr)
@@ -131,6 +132,14 @@ class UDROperatorCharm(CharmBase):
             event (NRFBrokenEvent): Juju event
         """
         self.unit.status = BlockedStatus("Waiting for fiveg_nrf relation")
+
+    def _on_database_relation_broken(self, event: EventBase) -> None:
+        """Event handler for database relation broken.
+
+        Args:
+            event: Juju event
+        """
+        self.unit.status = BlockedStatus("Waiting for database relation")
 
     def _on_certificates_relation_created(self, event: EventBase) -> None:
         """Generates Private key."""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -137,3 +137,29 @@ class TestUDROperatorCharm:
             relation1=APPLICATION_NAME, relation2=TLS_PROVIDER_CHARM_NAME
         )
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.skip(
+    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
+)
+@pytest.mark.abort_on_fail
+async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
+    assert ops_test.model
+    await ops_test.model.remove_application(DB_APPLICATION_NAME, block_until_done=True)
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=60)
+
+
+@pytest.mark.skip(
+    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
+)
+@pytest.mark.abort_on_fail
+async def test_restore_database_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
+    assert ops_test.model
+    await ops_test.model.deploy(
+        DB_APPLICATION_NAME,
+        application_name=DB_APPLICATION_NAME,
+        channel="5/edge",
+        trust=True,
+    )
+    await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=DB_APPLICATION_NAME)
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -40,7 +40,7 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
         self._container = self.harness.model.unit.get_container("udr")
 
-    def _database_is_available(self):
+    def _database_is_available(self) -> int:
         database_relation_id = self.harness.add_relation("database", "mongodb")
         self.harness.add_relation_unit(
             relation_id=database_relation_id, remote_unit_name="mongodb/0"
@@ -54,6 +54,7 @@ class TestCharm(unittest.TestCase):
                 "uris": "http://dummy",
             },
         )
+        return database_relation_id
 
     def test_given_database_relation_not_created_when_pebble_ready_then_status_is_blocked(self):
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
@@ -104,6 +105,28 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for fiveg_nrf relation"),
+        )
+
+    @patch("charm.check_output")
+    @patch("ops.model.Container.exists")
+    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
+    def test_given_udr_charm_in_active_status_when_database_relation_breaks_then_status_is_blocked(
+        self, patched_is_resource_created, patched_nrf_url, patched_exists, patched_check_output
+    ):
+        patched_exists.return_value = True
+        patched_check_output.return_value = "1.2.3.4".encode()
+        patched_is_resource_created.return_value = True
+        patched_nrf_url.return_value = "http://nrf:8081"
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
+        database_relation_id = self._database_is_available()
+        self.harness.container_pebble_ready("udr")
+
+        self.harness.remove_relation(database_relation_id)
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Waiting for database relation"),
         )
 
     def test_given_relations_created_but_database_not_available_when_pebble_ready_then_status_is_waiting(  # noqa: E501


### PR DESCRIPTION
# Description

This PR aims to fix #27. When database relation is removed, move into Blocked status.
As agreed, new integration tests are not executed until canonical/mongodb-k8s-operator#218 will be fixed.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library