### PR TITLE
docs: Adds Charmhub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,5 @@
-<div align="center">
-  <img src="./icon.svg" alt="ONF Icon" width="200" height="200">
-</div>
-<br/>
-<div align="center">
-  <a href="https://charmhub.io/sdcore-udr"><img src="https://charmhub.io/sdcore-udr/badge.svg" alt="CharmHub Badge"></a>
-  <a href="https://github.com/canonical/sdcore-udr-operator/actions/workflows/publish-charm.yaml">
-    <img src="https://github.com/canonical/sdcore-udr-operator/actions/workflows/publish-charm.yaml/badge.svg?branch=main" alt=".github/workflows/publish-charm.yaml">
-  </a>
-  <br/>
-  <br/>
-  <h1>SD-Core UDR Operator</h1>
-</div>
+# SD-Core UDR Operator (k8s)
+[![CharmHub Badge](https://charmhub.io/sdcore-udr/badge.svg)](https://charmhub.io/sdcore-udr)
 
 A Charmed Operator for SD-Core's Unified Data Repository (UDR) component. 
 


### PR DESCRIPTION
# Description

The Telco charms currently have broken statuses in the [charm engineering page](https://releases.juju.is/?team=Telco). This PR fixes this issues and brings the README.md in line with the other team's (ex. [Grafana K8s Operator](https://github.com/canonical/grafana-k8s-operator)).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library