### PR TITLE
chore: Use ops add_storage to reduce amount of mocking

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from io import StringIO
 from unittest.mock import Mock, PropertyMock, patch
 
 from ops import testing
@@ -39,6 +38,20 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(is_leader=True)
         self.harness.begin()
         self._container = self.harness.model.unit.get_container("udr")
+
+    @staticmethod
+    def _read_file(path: str) -> str:
+        """Reads a file and returns as a string.
+
+        Args:
+            path (str): path to the file.
+
+        Returns:
+            str: content of the file.
+        """
+        with open(path, "r") as f:
+            content = f.read()
+        return content
 
     def _database_is_available(self) -> int:
         database_relation_id = self.harness.add_relation("database", "mongodb")
@@ -84,18 +97,24 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("ops.model.Container.exists")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_charm_in_active_status_when_nrf_relation_breaks_then_status_is_blocked(
-        self, patched_is_resource_created, patched_nrf_url, patched_exists, patched_check_output
+        self, patched_is_resource_created, patched_nrf_url, patched_check_output
     ):
-        patched_exists.return_value = True
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        certificate = "whatever certificate content"
+        (root / "support/TLS/udr.pem").write_text(certificate)
         patched_check_output.return_value = "1.2.3.4".encode()
         patched_is_resource_created.return_value = True
         patched_nrf_url.return_value = "http://nrf:8081"
         nrf_relation_id = self.harness.add_relation(
             relation_name="fiveg_nrf", remote_app="some_nrf_app"
+        )
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
         )
         self._database_is_available()
         self.harness.container_pebble_ready("udr")
@@ -192,19 +211,17 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("ops.Container.push")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_relations_created_and_database_available_and_nrf_available_but_certificate_not_stored_when_pebble_ready_then_then_status_is_waiting(  # noqa: E501
         self,
         patched_is_resource_created,
         patched_nrf_url,
-        _,
         patched_check_output,
     ):
+        self.harness.add_storage(storage_name="config", attach=True)
         patched_check_output.return_value = "1.2.3.4".encode()
         patched_is_resource_created.return_value = True
-        self.harness.charm._storage_is_attached = Mock(return_value=True)
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
@@ -216,20 +233,20 @@ class TestCharm(unittest.TestCase):
             self.harness.model.unit.status, WaitingStatus("Waiting for certificates to be stored")
         )
 
-    @patch("ops.model.Container.push")
     @patch("charm.check_output")
-    @patch("ops.model.Container.exists")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_operator_ready_to_be_configured_when_pebble_ready_then_config_file_is_rendered_and_pushed(  # noqa: E501
         self,
         patched_is_resource_created,
         patched_nrf_url,
-        patched_exists,
         patched_check_output,
-        patched_push,
     ):
-        patched_exists.side_effect = [True, True, True, False]
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        certificate = "whatever certificate content"
+        (root / "support/TLS/udr.pem").write_text(certificate)
         patched_check_output.return_value = "1.2.3.4".encode()
         patched_is_resource_created.return_value = True
         patched_nrf_url.return_value = "http://nrf:8081"
@@ -241,32 +258,26 @@ class TestCharm(unittest.TestCase):
 
         self.harness.container_pebble_ready("udr")
 
-        with open("tests/unit/resources/expected_udrcfg.yaml") as expected_config_file:
-            expected_content = expected_config_file.read()
-            patched_push.assert_called_with(
-                path="/free5gc/config/udrcfg.yaml",
-                source=expected_content,
-                make_dirs=True,
-            )
+        expected_content = self._read_file("tests/unit/resources/expected_udrcfg.yaml")
 
-    @patch("ops.model.Container.push")
-    @patch("ops.model.Container.pull")
+        self.assertEqual((root / "free5gc/config/udrcfg.yaml").read_text(), expected_content)
+
     @patch("charm.check_output")
-    @patch("ops.model.Container.exists")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_config_is_different_from_the_newly_generated_config_when_pebble_ready_then_new_config_file_is_pushed(  # noqa: E501
         self,
         patched_is_resource_created,
         patched_nrf_url,
-        patched_exists,
         patched_check_output,
-        patched_pull,
-        patched_push,
     ):
-        patched_exists.side_effect = [True, True, True, False]
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        certificate = "whatever certificate content"
+        (root / "support/TLS/udr.pem").write_text(certificate)
+        (root / "free5gc/config/udrcfg.yaml").write_text("Dummy content")
         patched_check_output.return_value = "1.2.3.4".encode()
-        patched_pull.return_value = StringIO("Dummy content")
         patched_is_resource_created.return_value = True
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
@@ -277,61 +288,62 @@ class TestCharm(unittest.TestCase):
 
         self.harness.container_pebble_ready("udr")
 
-        with open("tests/unit/resources/expected_udrcfg.yaml") as expected_config_file:
-            expected_content = expected_config_file.read()
-            patched_push.assert_called_with(
-                path="/free5gc/config/udrcfg.yaml",
-                source=expected_content,
-                make_dirs=True,
-            )
+        expected_content = self._read_file("tests/unit/resources/expected_udrcfg.yaml")
 
-    @patch("ops.model.Container.push")
-    @patch("ops.model.Container.pull")
+        self.assertEqual((root / "free5gc/config/udrcfg.yaml").read_text(), expected_content)
+
     @patch("charm.check_output")
-    @patch("ops.model.Container.exists")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_config_is_the_same_as_the_newly_generated_config_when_pebble_ready_then_new_config_file_is_not_pushed(  # noqa: E501
         self,
         patched_is_resource_created,
         patched_nrf_url,
-        patched_exists,
         patched_check_output,
-        patched_pull,
-        patched_push,
     ):
-        patched_exists.side_effect = [True, False]
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        certificate = "whatever certificate content"
+        (root / "support/TLS/udr.pem").write_text(certificate)
+        (root / "free5gc/config/udrcfg.yaml").write_text(
+            self._read_file("tests/unit/resources/expected_udrcfg.yaml")
+        )
+        config_modification_time = (root / "free5gc/config/udrcfg.yaml").stat().st_mtime
+
         patched_check_output.return_value = "1.2.3.4".encode()
         patched_is_resource_created.return_value = True
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self._database_is_available()
 
-        with open("tests/unit/resources/expected_udrcfg.yaml") as expected_config_file:
-            expected_content = expected_config_file.read()
-            patched_pull.return_value = StringIO(expected_content)
-            self.harness.container_pebble_ready("udr")
+        self.harness.container_pebble_ready("udr")
 
-        patched_push.assert_not_called()
+        self.assertEqual(
+            (root / "free5gc/config/udrcfg.yaml").stat().st_mtime, config_modification_time
+        )
 
     @patch("ops.model.Container.restart")
-    @patch("ops.model.Container.pull")
     @patch("charm.check_output")
-    @patch("ops.model.Container.exists")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_service_already_configured_and_udr_config_is_different_from_the_newly_generated_config_when_pebble_ready_then_udr_service_is_restarted(  # noqa: E501
         self,
         patched_is_resource_created,
         patched_nrf_url,
-        patched_exists,
         patched_check_output,
-        patched_pull,
         patched_restart,
     ):
-        patched_exists.return_value = True
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        certificate = "whatever certificate content"
+        (root / "support/TLS/udr.pem").write_text(certificate)
+        (root / "free5gc/config/udrcfg.yaml").write_text("Dummy Content")
         patched_check_output.return_value = "1.2.3.4".encode()
-        patched_pull.return_value = StringIO("Dummy content")
         patched_is_resource_created.return_value = True
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
@@ -347,48 +359,56 @@ class TestCharm(unittest.TestCase):
         patched_restart.assert_called_once_with("udr")
 
     @patch("ops.model.Container.restart")
-    @patch("ops.model.Container.pull")
     @patch("charm.check_output")
-    @patch("ops.model.Container.exists")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_service_already_configured_and_udr_config_is_the_same_as_the_newly_generated_config_when_pebble_ready_then_udr_service_is_not_restarted(  # noqa: E501
         self,
         patched_is_resource_created,
         patched_nrf_url,
-        patched_exists,
         patched_check_output,
-        patched_pull,
         patched_restart,
     ):
-        patched_exists.side_effect = [True, False]
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        certificate = "whatever certificate content"
+        (root / "support/TLS/udr.pem").write_text(certificate)
+        (root / "free5gc/config/udrcfg.yaml").write_text(
+            self._read_file("tests/unit/resources/expected_udrcfg.yaml")
+        )
         patched_check_output.return_value = "1.2.3.4".encode()
         patched_is_resource_created.return_value = True
         patched_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="some_nrf_app")
         self._database_is_available()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
 
-        with open("tests/unit/resources/expected_udrcfg.yaml") as expected_config_file:
-            expected_content = expected_config_file.read()
-            patched_pull.return_value = StringIO(expected_content)
-            self.harness.set_can_connect(container="udr", val=True)
-            self._container.add_layer("udr", TEST_PEBBLE_LAYER, combine=True)
-            self.harness.container_pebble_ready("udr")
+        self.harness.set_can_connect(container="udr", val=True)
+        self._container.add_layer("udr", TEST_PEBBLE_LAYER, combine=True)
+        self.harness.container_pebble_ready("udr")
 
         patched_restart.assert_not_called()
 
     @patch("charm.check_output")
-    @patch("ops.model.Container.exists")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_config_is_pushed_when_pebble_ready_then_udr_service_is_configured_in_the_pebble(  # noqa: E501
         self,
         patched_is_resource_created,
         patched_nrf_url,
-        patched_exists,
         patched_check_output,
     ):
-        patched_exists.return_value = True
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        certificate = "whatever certificate content"
+        (root / "support/TLS/udr.pem").write_text(certificate)
+        (root / "free5gc/config/udrcfg.yaml").write_text(
+            self._read_file("tests/unit/resources/expected_udrcfg.yaml")
+        )
         patched_check_output.return_value = "1.2.3.4".encode()
         patched_is_resource_created.return_value = True
         patched_nrf_url.return_value = "http://nrf:8081"
@@ -405,18 +425,23 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
-    @patch("ops.model.Container.exists")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_config_is_pushed_when_pebble_ready_then_udr_service_is_restarted(
         self,
         patched_is_resource_created,
         patched_nrf_url,
-        patched_exists,
         patched_check_output,
         patched_restart,
     ):
-        patched_exists.return_value = True
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        certificate = "whatever certificate content"
+        (root / "support/TLS/udr.pem").write_text(certificate)
+        (root / "free5gc/config/udrcfg.yaml").write_text(
+            self._read_file("tests/unit/resources/expected_udrcfg.yaml")
+        )
         patched_check_output.return_value = "1.2.3.4".encode()
         patched_is_resource_created.return_value = True
         patched_nrf_url.return_value = "http://nrf:8081"
@@ -429,17 +454,22 @@ class TestCharm(unittest.TestCase):
         patched_restart.assert_called_once_with("udr")
 
     @patch("charm.check_output")
-    @patch("ops.model.Container.exists")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_config_is_pushed_when_pebble_ready_then_status_is_active(
         self,
         patched_is_resource_created,
         patched_nrf_url,
-        patched_exists,
         patched_check_output,
     ):
-        patched_exists.return_value = True
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        certificate = "whatever certificate content"
+        (root / "support/TLS/udr.pem").write_text(certificate)
+        (root / "free5gc/config/udrcfg.yaml").write_text(
+            self._read_file("tests/unit/resources/expected_udrcfg.yaml")
+        )
         patched_check_output.return_value = "1.2.3.4".encode()
         patched_is_resource_created.return_value = True
         patched_nrf_url.return_value = "http://nrf:8081"
@@ -455,17 +485,15 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("ops.model.Container.exists")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_ip_not_available_when_pebble_ready_then_status_is_waiting(
         self,
         patched_is_resource_created,
         patched_nrf_url,
-        patched_exists,
         patched_check_output,
     ):
-        patched_exists.return_value = True
+        self.harness.add_storage(storage_name="config", attach=True)
         patched_check_output.return_value = "".encode()
         patched_is_resource_created.return_value = True
         patched_nrf_url.return_value = "http://nrf:8081"
@@ -483,71 +511,74 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.generate_private_key")
-    @patch("ops.model.Container.push")
     def test_given_can_connect_when_on_certificates_relation_created_then_private_key_is_generated(
-        self, patch_push, patch_generate_private_key
+        self, patch_generate_private_key
     ):
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root("udr")
         private_key = b"whatever key content"
         self.harness.set_can_connect(container="udr", val=True)
         patch_generate_private_key.return_value = private_key
 
         self.harness.charm._on_certificates_relation_created(event=Mock)
+        self.assertEqual((root / "support/TLS/udr.key").read_text(), private_key.decode())
 
-        patch_push.assert_called_with(path="/support/TLS/udr.key", source=private_key.decode())
-
-    @patch("ops.model.Container.remove_path")
-    @patch("ops.model.Container.exists")
     def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_certificates_are_removed(  # noqa: E501
-        self, patch_exists, patch_remove_path
+        self,
     ):
-        patch_exists.return_value = True
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        private_key = "Whatever key content"
+        csr = "Whatever CSR content"
+        certificate = "Whatever certificate content"
+        (root / "support/TLS/udr.key").write_text(private_key)
+        (root / "support/TLS/udr.csr").write_text(csr)
+        (root / "support/TLS/udr.pem").write_text(certificate)
         self.harness.set_can_connect(container="udr", val=True)
 
         self.harness.charm._on_certificates_relation_broken(event=Mock)
-
-        patch_remove_path.assert_any_call(path="/support/TLS/udr.pem")
-        patch_remove_path.assert_any_call(path="/support/TLS/udr.key")
-        patch_remove_path.assert_any_call(path="/support/TLS/udr.csr")
+        with self.assertRaises(FileNotFoundError):
+            (root / "support/TLS/udr.key").read_text()
+        with self.assertRaises(FileNotFoundError):
+            (root / "support/TLS/udr.pem").read_text()
+        with self.assertRaises(FileNotFoundError):
+            (root / "support/TLS/udr.csr").read_text()
 
     @patch(
         "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation",  # noqa: E501
         new=Mock,
     )
-    @patch("ops.model.Container.push")
     @patch("charm.generate_csr")
-    @patch("ops.model.Container.pull")
-    @patch("ops.model.Container.exists")
     def test_given_private_key_exists_when_on_certificates_relation_joined_then_csr_is_generated(
-        self, patch_exists, patch_pull, patch_generate_csr, patch_push
+        self, patch_generate_csr
     ):
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        private_key = "private key content"
+        (root / "support/TLS/udr.key").write_text(private_key)
         csr = b"whatever csr content"
         patch_generate_csr.return_value = csr
-        patch_pull.return_value = StringIO("private key content")
-        patch_exists.side_effect = [True, False]
         self.harness.set_can_connect(container="udr", val=True)
 
         self.harness.charm._on_certificates_relation_joined(event=Mock)
 
-        patch_push.assert_called_with(path="/support/TLS/udr.csr", source=csr.decode())
+        self.assertEqual((root / "support/TLS/udr.csr").read_text(), csr.decode())
 
     @patch(
         "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation",  # noqa: E501
     )
-    @patch("ops.model.Container.push", new=Mock)
     @patch("charm.generate_csr")
-    @patch("ops.model.Container.pull")
-    @patch("ops.model.Container.exists")
     def test_given_private_key_exists_and_cert_not_yet_requested_when_on_certificates_relation_joined_then_cert_is_requested(  # noqa: E501
         self,
-        patch_exists,
-        patch_pull,
         patch_generate_csr,
         patch_request_certificate_creation,
     ):
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        private_key = "private key content"
+        (root / "support/TLS/udr.key").write_text(private_key)
         csr = b"whatever csr content"
         patch_generate_csr.return_value = csr
-        patch_pull.return_value = StringIO("private key content")
-        patch_exists.side_effect = [True, False]
         self.harness.set_can_connect(container="udr", val=True)
 
         self.harness.charm._on_certificates_relation_joined(event=Mock)
@@ -557,35 +588,29 @@ class TestCharm(unittest.TestCase):
     @patch(
         "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation",  # noqa: E501
     )
-    @patch("ops.model.Container.push", new=Mock)
-    @patch("ops.model.Container.pull")
-    @patch("ops.model.Container.exists")
     def test_given_cert_already_stored_when_on_certificates_relation_joined_then_cert_is_not_requested(  # noqa: E501
         self,
-        patch_exists,
-        patch_pull,
         patch_request_certificate_creation,
     ):
-        patch_pull.return_value = StringIO("private key content")
-        patch_exists.return_value = True
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        private_key = "private key content"
+        certificate = "Whatever certificate content"
+        (root / "support/TLS/udr.key").write_text(private_key)
+        (root / "support/TLS/udr.pem").write_text(certificate)
         self.harness.set_can_connect(container="udr", val=True)
 
         self.harness.charm._on_certificates_relation_joined(event=Mock)
 
-        patch_request_certificate_creation.assert_not_called
+        patch_request_certificate_creation.assert_not_called()
 
-    @patch("ops.model.Container.pull")
-    @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.push")
     def test_given_csr_matches_stored_one_when_certificate_available_then_certificate_is_pushed(
         self,
-        patch_push,
-        patch_exists,
-        patch_pull,
     ):
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root("udr")
         csr = "Whatever CSR content"
-        patch_pull.return_value = StringIO(csr)
-        patch_exists.return_value = True
+        (root / "support/TLS/udr.csr").write_text(csr)
         certificate = "Whatever certificate content"
         event = Mock()
         event.certificate = certificate
@@ -594,19 +619,15 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm._on_certificate_available(event=event)
 
-        patch_push.assert_called_with(path="/support/TLS/udr.pem", source=certificate)
+        self.assertEqual((root / "support/TLS/udr.pem").read_text(), certificate)
 
-    @patch("ops.model.Container.pull")
-    @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.push")
     def test_given_csr_doesnt_match_stored_one_when_certificate_available_then_certificate_is_not_pushed(  # noqa: E501
         self,
-        patch_push,
-        patch_exists,
-        patch_pull,
     ):
-        patch_pull.return_value = StringIO("Stored CSR content")
-        patch_exists.return_value = True
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        csr = "Stored CSR content"
+        (root / "support/TLS/udr.csr").write_text(csr)
         certificate = "Whatever certificate content"
         event = Mock()
         event.certificate = certificate
@@ -615,19 +636,21 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm._on_certificate_available(event=event)
 
-        patch_push.assert_not_called()
+        with self.assertRaises(FileNotFoundError):
+            (root / "support/TLS/udr.pem").read_text()
 
     @patch(
         "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation",  # noqa: E501
     )
-    @patch("ops.model.Container.push", new=Mock)
     @patch("charm.generate_csr")
-    @patch("ops.model.Container.pull")
     def test_given_certificate_does_not_match_stored_one_when_certificate_expiring_then_certificate_is_not_requested(  # noqa: E501
-        self, patch_pull, patch_generate_csr, patch_request_certificate_creation
+        self, patch_generate_csr, patch_request_certificate_creation
     ):
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        certificate = "Stored certificate content"
+        (root / "support/TLS/udr.pem").write_text(certificate)
         event = Mock()
-        patch_pull.return_value = StringIO("Stored certificate content")
         event.certificate = "Relation certificate content (different from stored)"
         csr = b"whatever csr content"
         patch_generate_csr.return_value = csr
@@ -640,16 +663,18 @@ class TestCharm(unittest.TestCase):
     @patch(
         "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation",  # noqa: E501
     )
-    @patch("ops.model.Container.push", new=Mock)
     @patch("charm.generate_csr")
-    @patch("ops.model.Container.pull")
     def test_given_certificate_matches_stored_one_when_certificate_expiring_then_certificate_is_requested(  # noqa: E501
-        self, patch_pull, patch_generate_csr, patch_request_certificate_creation
+        self, patch_generate_csr, patch_request_certificate_creation
     ):
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root("udr")
+        private_key = "private key content"
         certificate = "whatever certificate content"
+        (root / "support/TLS/udr.key").write_text(private_key)
+        (root / "support/TLS/udr.pem").write_text(certificate)
         event = Mock()
         event.certificate = certificate
-        patch_pull.return_value = StringIO(certificate)
         csr = b"whatever csr content"
         patch_generate_csr.return_value = csr
         self.harness.set_can_connect(container="udr", val=True)


### PR DESCRIPTION
# Description

This PR aims to replace mock objects for Container `pull`, `push`, `exists`, `remove_path` leveraging the new `ops.harness.add_storage` method.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library