### PR TITLE
chore: Removing --trust flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A Charmed Operator for SD-Core's Unified Data Repository (UDR) component.
 
 ```bash
 juju deploy mongodb-k8s --trust --channel=5/edge
-juju deploy sdcore-nrf --trust --channel=edge
-juju deploy sdcore-udr --trust --channel=edge
+juju deploy sdcore-nrf --channel=edge
+juju deploy sdcore-udr --channel=edge
 juju deploy self-signed-certificates --channel=beta
 juju integrate mongodb-k8s sdcore-nrf
 juju integrate mongodb-k8s sdcore-udr:database


### PR DESCRIPTION
# Description

Removes the `--trust` flag. After replacing `KubernetesServicePatch` with `ops.set_ports` it's not needed anymore.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library