### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@main
     with:
-      charm-file-name: "sdcore-udr_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-udr-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -39,5 +39,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-udr_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-udr-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core UDR Operator for K8s
+# SD-Core UDR Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-udr-k8s/badge.svg)](https://charmhub.io/sdcore-udr-k8s)
 
 A Charmed Operator for SD-Core's Unified Data Repository (UDR) component for K8s. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core UDR K8s Operator
+# SD-Core UDR Operator for K8s
 [![CharmHub Badge](https://charmhub.io/sdcore-udr-k8s/badge.svg)](https://charmhub.io/sdcore-udr-k8s)
 
-A Charmed K8s Operator for SD-Core's Unified Data Repository (UDR) component. 
+A Charmed Operator for SD-Core's Unified Data Repository (UDR) component for K8s. 
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# SD-Core UDR Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-udr/badge.svg)](https://charmhub.io/sdcore-udr)
+# SD-Core UDR K8s Operator
+[![CharmHub Badge](https://charmhub.io/sdcore-udr-k8s/badge.svg)](https://charmhub.io/sdcore-udr-k8s)
 
-A Charmed Operator for SD-Core's Unified Data Repository (UDR) component. 
+A Charmed K8s Operator for SD-Core's Unified Data Repository (UDR) component. 
 
 ## Usage
 
 ```bash
 juju deploy mongodb-k8s --trust --channel=5/edge
-juju deploy sdcore-nrf --channel=edge
-juju deploy sdcore-udr --channel=edge
+juju deploy sdcore-nrf-k8s --channel=edge
+juju deploy sdcore-udr-k8s --channel=edge
 juju deploy self-signed-certificates --channel=beta
-juju integrate mongodb-k8s sdcore-nrf
-juju integrate mongodb-k8s sdcore-udr:database
-juju integrate sdcore-nrf:certificates self-signed-certificates:certificates
-juju integrate sdcore-nrf sdcore-udr:fiveg_nrf
-juju integrate sdcore-udr:certificates self-signed-certificates:certificates
+juju integrate mongodb-k8s sdcore-nrf-k8s
+juju integrate mongodb-k8s sdcore-udr-k8s:database
+juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
+juju integrate sdcore-nrf-k8s:fiveg_nrf sdcore-udr-k8s:fiveg_nrf
+juju integrate sdcore-udr-k8s:certificates self-signed-certificates:certificates
 ```
 
 ## Image

--- a/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
@@ -13,7 +13,7 @@ NRF information and another charm requiring this information.
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.sdcore_nrf.v0.fiveg_nrf
+charmcraft fetch-lib charms.sdcore_nrf_k8s.v0.fiveg_nrf
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -28,7 +28,7 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFProvides
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFProvides
 
 
 class DummyFiveGNRFProviderCharm(CharmBase):
@@ -103,14 +103,14 @@ from ops.model import Relation
 from pydantic import AnyHttpUrl, BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "cd132a12c2b34243bfd2bae8d08c32d6"
+LIBID = "14746bb6f8d34accbeac27ea50ff4715"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 1
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,12 +1,12 @@
-name: sdcore-udr
+name: sdcore-udr-k8s
 
-display-name: SD-Core UDR
+display-name: SD-Core UDR K8s
 summary: A Charmed Operator for SD-Core's UDR component.
 description: |
   A Charmed Operator for SD-Core's Unified Data Repository (UDR) component.
-website: https://charmhub.io/sdcore-udr
-source: https://github.com/canonical/sdcore-udr-operator
-issues: https://github.com/canonical/sdcore-udr-operator/issues
+website: https://charmhub.io/sdcore-udr-k8s
+source: https://github.com/canonical/sdcore-udr-k8s-operator
+issues: https://github.com/canonical/sdcore-udr-k8s-operator/issues
 
 containers:
   udr:

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the SD-Core's UDR service."""
+"""Charmed K8s operator for the SD-Core's UDR service."""
 
 import logging
 from ipaddress import IPv4Address
@@ -37,7 +37,7 @@ CERTIFICATE_NAME = "udr.pem"
 CERTIFICATE_COMMON_NAME = "udr.sdcore"
 
 
-class UDROperatorCharm(CharmBase):
+class UDRK8sOperatorCharm(CharmBase):
     """Charm the service."""
 
     def __init__(self, *args):
@@ -463,4 +463,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(UDROperatorCharm)
+    main(UDRK8sOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed K8s operator for the SD-Core's UDR service."""
+"""Charmed operator for the SD-Core's UDR service for K8s."""
 
 import logging
 from ipaddress import IPv4Address
@@ -37,7 +37,7 @@ CERTIFICATE_NAME = "udr.pem"
 CERTIFICATE_COMMON_NAME = "udr.sdcore"
 
 
-class UDRK8sOperatorCharm(CharmBase):
+class UDROperatorCharm(CharmBase):
     """Charm the service."""
 
     def __init__(self, *args):
@@ -463,4 +463,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(UDRK8sOperatorCharm)
+    main(UDROperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ from subprocess import CalledProcessError, check_output
 from typing import Optional
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires  # type: ignore[import]
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     CertificateAvailableEvent,
     CertificateExpiringEvent,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -15,7 +15,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APPLICATION_NAME = METADATA["name"]
 
 DB_APPLICATION_NAME = "mongodb-k8s"
-NRF_APPLICATION_NAME = "sdcore-nrf"
+NRF_APPLICATION_NAME = "sdcore-nrf-k8s"
 TLS_PROVIDER_CHARM_NAME = "self-signed-certificates"
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -517,7 +517,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_called_process_error_thrown_while_fetching_pod_ip_when_pebble_ready_then_status_is_waiting(  # noqa: E501
         self, patched_is_resource_created, patched_nrf_url, patched_check_output

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, PropertyMock, patch
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import UDRK8sOperatorCharm
+from charm import UDROperatorCharm
 
 TEST_PEBBLE_LAYER = {
     "services": {
@@ -32,7 +32,7 @@ TEST_PEBBLE_LAYER = {
 class TestCharm(unittest.TestCase):
     def setUp(self):
         self.namespace = "whatever"
-        self.harness = testing.Harness(UDRK8sOperatorCharm)
+        self.harness = testing.Harness(UDROperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(is_leader=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, PropertyMock, patch
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import UDROperatorCharm
+from charm import UDRK8sOperatorCharm
 
 TEST_PEBBLE_LAYER = {
     "services": {
@@ -32,7 +32,7 @@ TEST_PEBBLE_LAYER = {
 class TestCharm(unittest.TestCase):
     def setUp(self):
         self.namespace = "whatever"
-        self.harness = testing.Harness(UDROperatorCharm)
+        self.harness = testing.Harness(UDRK8sOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(is_leader=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -97,7 +97,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_charm_in_active_status_when_nrf_relation_breaks_then_status_is_blocked(
         self, patched_is_resource_created, patched_nrf_url, patched_check_output
@@ -127,7 +127,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_charm_in_active_status_when_database_relation_breaks_then_status_is_blocked(
         self, patched_is_resource_created, patched_nrf_url, patched_check_output
@@ -199,7 +199,7 @@ class TestCharm(unittest.TestCase):
             self.harness.model.unit.status, WaitingStatus("Waiting for the NRF to be available")
         )
 
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_relations_created_and_database_available_and_nrf_available_but_storage_not_attached_when_pebble_ready_then_then_status_is_waiting(  # noqa: E501
         self, patched_is_resource_created, patched_nrf_url
@@ -217,7 +217,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_relations_created_and_database_available_and_nrf_available_but_certificate_not_stored_when_pebble_ready_then_then_status_is_waiting(  # noqa: E501
         self,
@@ -240,7 +240,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_operator_ready_to_be_configured_when_pebble_ready_then_config_file_is_rendered_and_pushed(  # noqa: E501
         self,
@@ -269,7 +269,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual((root / "free5gc/config/udrcfg.yaml").read_text(), expected_content)
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_config_is_different_from_the_newly_generated_config_when_pebble_ready_then_new_config_file_is_pushed(  # noqa: E501
         self,
@@ -299,7 +299,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual((root / "free5gc/config/udrcfg.yaml").read_text(), expected_content)
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_config_is_the_same_as_the_newly_generated_config_when_pebble_ready_then_new_config_file_is_not_pushed(  # noqa: E501
         self,
@@ -334,7 +334,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_service_already_configured_and_udr_config_is_different_from_the_newly_generated_config_when_pebble_ready_then_udr_service_is_restarted(  # noqa: E501
         self,
@@ -366,7 +366,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_service_already_configured_and_udr_config_is_the_same_as_the_newly_generated_config_when_pebble_ready_then_udr_service_is_not_restarted(  # noqa: E501
         self,
@@ -399,7 +399,7 @@ class TestCharm(unittest.TestCase):
         patched_restart.assert_not_called()
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_config_is_pushed_when_pebble_ready_then_udr_service_is_configured_in_the_pebble(  # noqa: E501
         self,
@@ -431,7 +431,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_config_is_pushed_when_pebble_ready_then_udr_service_is_restarted(
         self,
@@ -460,7 +460,7 @@ class TestCharm(unittest.TestCase):
         patched_restart.assert_called_once_with("udr")
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_udr_config_is_pushed_when_pebble_ready_then_status_is_active(
         self,
@@ -491,7 +491,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_ip_not_available_when_pebble_ready_then_status_is_waiting(
         self,


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit).
 
- Fetch new fiveg_nrf library
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library